### PR TITLE
Fix server fallback

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
@@ -179,6 +179,11 @@ public class Utils {
 
             String responseStr = response.body().string();
 
+            if (!response.isSuccessful()) {
+                Log.e("UTIL", "Unsuccessful response: " + response.message() + "\n" + responseStr);
+                return null;
+            }
+
             writeFileCache(ctx, theURI, responseStr);
             if (BuildConfig.DEBUG) {
                 Log.d("UTIL", "wrote cache file for:" + theURI);


### PR DESCRIPTION
The server fallback is activated only if `downloadFeed` returns `null`, which previously happened only if an exception was thrown. This happens e.g. if the server is totally offline and thus the connection times out, but it doesn’t happen if the server is online but doesn’t work (which is the case right now: https://de1.api.radio-browser.info/ is online, but reports 503 Service Unavailable). Change `Utils.downloadFeed()` to log an error and return `null` if there is an HTTP response, but it’s unsuccessful (i.e. the status code is not in the 2xx range). Returning `null` triggers the fallback mechanism.